### PR TITLE
updates v:0.0.3 - db_schema redirect to and from - routerPlugin checks redirects in db

### DIFF
--- a/Plugin/RouterPlugin.php
+++ b/Plugin/RouterPlugin.php
@@ -45,6 +45,13 @@ class RouterPlugin {
         $redirects = $this->redirectsFactory->create();
         $match = $redirects->getCollection()->addFieldToFilter('from', ['eq'=> $requestPath])->getData();
 
+        if(!count($match)) {
+            $urlComponents = parse_url($requestPath);
+            $filteredURL = $urlComponents['path'];
+
+            $match = $redirects->getCollection()->addFieldToFilter('from', ['eq' => $filteredURL])->getData();
+        }
+
         if(count($match)) {
             $this->responseFactory->create()->setRedirect($match[0]['to'], 301)->sendResponse();
             exit;

--- a/Plugin/RouterPlugin.php
+++ b/Plugin/RouterPlugin.php
@@ -45,14 +45,14 @@ class RouterPlugin {
         $redirects = $this->redirectsFactory->create();
         $match = $redirects->getCollection()->addFieldToFilter('from', ['eq'=> $requestPath])->getData();
 
-        if(!count($match)) {
+        if (!count($match)) {
             $urlComponents = parse_url($requestPath);
             $filteredURL = $urlComponents['path'];
 
             $match = $redirects->getCollection()->addFieldToFilter('from', ['eq' => $filteredURL])->getData();
         }
 
-        if(count($match)) {
+        if (count($match)) {
             $this->responseFactory->create()->setRedirect($match[0]['to'], 301)->sendResponse();
             exit;
         }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "scandiweb/module-core": "~0.1.2",
     "scandiweb/module-migration": "^1.0"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "autoload": {
     "files": [
       "registration.php"

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * @category  ScandiPWA
+ * @package   ScandiPWA_CustomRedirects
+ * @author    Vitalijs Visnakovs <info@scandiweb.com>
+ * @copyright Copyright (c) 2023 Scandiweb, Inc (http://scandiweb.com)
+ */
+-->
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="scandipwa_redirects">
+        <column xsi:type="varchar" length="1024" name="from" comment="Redirect From"/>
+        <column xsi:type="varchar" length="1024" name="to" comment="Redirect To"/>
+    </table>
+</schema>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -2,7 +2,7 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="ScandiPWA_CustomRedirects" setup_version="0.0.2">
+    <module name="ScandiPWA_CustomRedirects" setup_version="0.0.3">
         <sequence>
             <module name="ScandiPWA_Route717"/>
         </sequence>


### PR DESCRIPTION
-- Novatours extension updates
It was requested for this to be merged to the extension

We need to update the extension on composer so that it ignores query parameters and matches the path even if query parameters are not matched.
We can also update the schema to use the new schema db_schema instead of installSchema